### PR TITLE
feat: add service-base chart

### DIFF
--- a/.github/workflows/release-chart.yaml
+++ b/.github/workflows/release-chart.yaml
@@ -1,0 +1,46 @@
+name: Release Helm Chart
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.14.0
+
+      - name: Set version
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+
+      - name: Helm lint
+        run: helm lint charts/service-base
+
+      - name: Package chart
+        run: |
+          helm package charts/service-base \
+            --version "$VERSION" \
+            --app-version "$VERSION" \
+            --destination dist
+
+      - name: Login to GHCR
+        run: |
+          helm registry login ghcr.io \
+            -u "${{ github.actor }}" \
+            -p "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Push chart
+        run: helm push "dist/service-base-$VERSION.tgz" oci://ghcr.io/agynio/helm

--- a/charts/service-base/Chart.yaml
+++ b/charts/service-base/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: service-base
+description: Common library chart for service workloads.
+type: library
+version: 0.1.0
+appVersion: "0.1.0"

--- a/charts/service-base/README.md
+++ b/charts/service-base/README.md
@@ -1,0 +1,79 @@
+# service-base
+
+`service-base` is a Helm library chart that provides common templates for
+service workloads. It is designed to be included by service charts rather than
+installed directly.
+
+## Usage
+
+Add the library chart as a dependency:
+
+```yaml
+# Chart.yaml
+dependencies:
+  - name: service-base
+    version: 0.1.0
+    repository: oci://ghcr.io/agynio/helm
+```
+
+Then include the templates in your chart:
+
+```yaml
+# templates/deployment.yaml
+{{- include "service-base.deployment" . }}
+```
+
+```yaml
+# templates/service.yaml
+{{- include "service-base.service" . }}
+```
+
+Other available templates:
+
+- `service-base.ingress`
+- `service-base.hpa`
+- `service-base.pdb`
+- `service-base.serviceAccount`
+- `service-base.rbac`
+- `service-base.configMounts` (volume mounts helper)
+- `service-base.servicemonitor`
+
+## Values
+
+Key values (see `values.yaml` for full list):
+
+- `image.repository` (required)
+- `image.tag` (defaults to `.Chart.AppVersion`)
+- `global.imagePullSecrets` and `image.pullSecrets` (merged in PodSpec)
+- `service.port`, `service.targetPort`, `service.portName`
+- `ingress.hosts[].paths[]` for HTTP routing
+- `autoscaling` for HPA targets/behavior
+- `pdb` for PodDisruptionBudget settings
+- `configMounts` to mount existing ConfigMaps/Secrets
+- `metrics.serviceMonitor` for Prometheus Operator ServiceMonitors
+
+### Example values for a service chart
+
+```yaml
+image:
+  repository: ghcr.io/agynio/my-service
+
+service:
+  port: 8080
+  targetPort: http
+
+ingress:
+  enabled: true
+  hosts:
+    - host: api.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+          servicePort: http
+
+configMounts:
+  - name: my-service-config
+    type: configMap
+    mountPath: /etc/service/config.yaml
+    subPath: config.yaml
+```

--- a/charts/service-base/README.md
+++ b/charts/service-base/README.md
@@ -47,10 +47,13 @@ Key values (see `values.yaml` for full list):
 - `global.imageRegistry` and `image.registry` (registry resolution)
 - `global.imagePullSecrets` and `image.pullSecrets` (merged in PodSpec)
 - `service.ports[]` for service ports
+- `service.labels` for extra service metadata labels
 - `ingress.ingressClassName` and `ingress.hosts[].paths[]`
 - `autoscaling` for HPA targets/behavior
 - `pdb` for PodDisruptionBudget settings
 - `configMounts[].sourceName` to mount existing ConfigMaps/Secrets
+- `securityContext.enabled` with hardened defaults
+- `lifecycle` for container lifecycle hooks
 - `metrics.serviceMonitor` for Prometheus Operator ServiceMonitors
 
 ### Example values for a service chart

--- a/charts/service-base/README.md
+++ b/charts/service-base/README.md
@@ -35,8 +35,8 @@ Other available templates:
 - `service-base.pdb`
 - `service-base.serviceAccount`
 - `service-base.rbac`
-- `service-base.configMounts` (volume mounts helper)
-- `service-base.servicemonitor`
+- `service-base.config` (volume mounts helper)
+- `service-base.metrics`
 
 ## Values
 
@@ -44,12 +44,13 @@ Key values (see `values.yaml` for full list):
 
 - `image.repository` (required)
 - `image.tag` (defaults to `.Chart.AppVersion`)
+- `global.imageRegistry` and `image.registry` (registry resolution)
 - `global.imagePullSecrets` and `image.pullSecrets` (merged in PodSpec)
-- `service.port`, `service.targetPort`, `service.portName`
-- `ingress.hosts[].paths[]` for HTTP routing
+- `service.ports[]` for service ports
+- `ingress.ingressClassName` and `ingress.hosts[].paths[]`
 - `autoscaling` for HPA targets/behavior
 - `pdb` for PodDisruptionBudget settings
-- `configMounts` to mount existing ConfigMaps/Secrets
+- `configMounts[].sourceName` to mount existing ConfigMaps/Secrets
 - `metrics.serviceMonitor` for Prometheus Operator ServiceMonitors
 
 ### Example values for a service chart
@@ -59,8 +60,10 @@ image:
   repository: ghcr.io/agynio/my-service
 
 service:
-  port: 8080
-  targetPort: http
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
 
 ingress:
   enabled: true
@@ -73,6 +76,7 @@ ingress:
 
 configMounts:
   - name: my-service-config
+    sourceName: my-service-config
     type: configMap
     mountPath: /etc/service/config.yaml
     subPath: config.yaml

--- a/charts/service-base/templates/_deployment.tpl
+++ b/charts/service-base/templates/_deployment.tpl
@@ -83,6 +83,10 @@ spec:
           securityContext:
 {{ $containerSecurityContext | nindent 12 }}
 {{- end }}
+{{- with .Values.lifecycle }}
+          lifecycle:
+{{ toYaml . | nindent 12 }}
+{{- end }}
 {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
 {{ omit .Values.livenessProbe "enabled" | toYaml | nindent 12 }}

--- a/charts/service-base/templates/_deployment.tpl
+++ b/charts/service-base/templates/_deployment.tpl
@@ -1,0 +1,107 @@
+{{- define "service-base.deployment" -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "service-base.fullname" . }}
+  labels:
+{{ include "service-base.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  selector:
+    matchLabels:
+{{ include "service-base.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+{{ include "service-base.selectorLabels" . | nindent 8 }}
+{{- with .Values.podLabels }}
+{{ toYaml . | nindent 8 }}
+{{- end }}
+{{- with .Values.podAnnotations }}
+      annotations:
+{{ toYaml . | nindent 8 }}
+{{- end }}
+    spec:
+      serviceAccountName: {{ include "service-base.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
+{{ include "service-base.imagePullSecrets" . | nindent 6 }}
+{{- with .Values.podSecurityContext }}
+      securityContext:
+{{ toYaml . | nindent 8 }}
+{{- end }}
+      containers:
+        - name: {{ include "service-base.name" . }}
+          image: {{ include "service-base.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+{{- if .Values.command }}
+          command:
+{{ toYaml .Values.command | nindent 12 }}
+{{- end }}
+{{- if .Values.args }}
+          args:
+{{ toYaml .Values.args | nindent 12 }}
+{{- end }}
+          ports:
+{{ toYaml .Values.containerPorts | nindent 12 }}
+{{- if .Values.env }}
+          env:
+{{ toYaml .Values.env | nindent 12 }}
+{{- end }}
+{{- if .Values.envFrom }}
+          envFrom:
+{{ toYaml .Values.envFrom | nindent 12 }}
+{{- end }}
+{{- with .Values.resources }}
+          resources:
+{{ toYaml . | nindent 12 }}
+{{- end }}
+{{- with .Values.containerSecurityContext }}
+          securityContext:
+{{ toYaml . | nindent 12 }}
+{{- end }}
+{{- with .Values.livenessProbe }}
+          livenessProbe:
+{{ toYaml . | nindent 12 }}
+{{- end }}
+{{- with .Values.readinessProbe }}
+          readinessProbe:
+{{ toYaml . | nindent 12 }}
+{{- end }}
+{{- with .Values.startupProbe }}
+          startupProbe:
+{{ toYaml . | nindent 12 }}
+{{- end }}
+{{- if or .Values.configMounts .Values.extraVolumeMounts }}
+          volumeMounts:
+{{- if .Values.configMounts }}
+{{ include "service-base.configMounts" . | nindent 12 }}
+{{- end }}
+{{- if .Values.extraVolumeMounts }}
+{{ toYaml .Values.extraVolumeMounts | nindent 12 }}
+{{- end }}
+{{- end }}
+{{- if or .Values.configMounts .Values.extraVolumes }}
+      volumes:
+{{- if .Values.configMounts }}
+{{ include "service-base.configVolumes" . | nindent 8 }}
+{{- end }}
+{{- if .Values.extraVolumes }}
+{{ toYaml .Values.extraVolumes | nindent 8 }}
+{{- end }}
+{{- end }}
+{{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | nindent 8 }}
+{{- end }}
+{{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | nindent 8 }}
+{{- end }}
+{{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | nindent 8 }}
+{{- end }}
+{{- end -}}

--- a/charts/service-base/templates/_deployment.tpl
+++ b/charts/service-base/templates/_deployment.tpl
@@ -5,11 +5,20 @@ metadata:
   name: {{ include "service-base.fullname" . }}
   labels:
 {{ include "service-base.labels" . | nindent 4 }}
+  {{- $annotations := include "service-base.commonAnnotations" . }}
+  {{- if $annotations }}
+  annotations:
+{{ $annotations | nindent 4 }}
+  {{- end }}
 spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  {{- with .Values.updateStrategy }}
+  strategy:
+{{ toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
 {{ include "service-base.selectorLabels" . | nindent 6 }}
@@ -25,12 +34,23 @@ spec:
 {{ toYaml . | nindent 8 }}
 {{- end }}
     spec:
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}
+      {{- if not (eq .Values.terminationGracePeriodSeconds nil) }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- end }}
       serviceAccountName: {{ include "service-base.serviceAccountName" . }}
       automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
 {{ include "service-base.imagePullSecrets" . | nindent 6 }}
-{{- with .Values.podSecurityContext }}
+{{- $podSecurityContext := include "service-base.podSecurityContext" . }}
+{{- if $podSecurityContext }}
       securityContext:
-{{ toYaml . | nindent 8 }}
+{{ $podSecurityContext | nindent 8 }}
+{{- end }}
+{{- if .Values.initContainers }}
+      initContainers:
+{{ toYaml .Values.initContainers | nindent 8 }}
 {{- end }}
       containers:
         - name: {{ include "service-base.name" . }}
@@ -46,51 +66,61 @@ spec:
 {{- end }}
           ports:
 {{ toYaml .Values.containerPorts | nindent 12 }}
-{{- if .Values.env }}
-          env:
-{{ toYaml .Values.env | nindent 12 }}
+{{- $env := include "service-base.renderEnv" . }}
+{{- if $env }}
+{{ $env | nindent 10 }}
 {{- end }}
-{{- if .Values.envFrom }}
-          envFrom:
-{{ toYaml .Values.envFrom | nindent 12 }}
+{{- $envFrom := include "service-base.renderEnvFrom" . }}
+{{- if $envFrom }}
+{{ $envFrom | nindent 10 }}
 {{- end }}
 {{- with .Values.resources }}
           resources:
 {{ toYaml . | nindent 12 }}
 {{- end }}
-{{- with .Values.containerSecurityContext }}
+{{- $containerSecurityContext := include "service-base.securityContext" . }}
+{{- if $containerSecurityContext }}
           securityContext:
-{{ toYaml . | nindent 12 }}
+{{ $containerSecurityContext | nindent 12 }}
 {{- end }}
-{{- with .Values.livenessProbe }}
+{{- if .Values.livenessProbe.enabled }}
           livenessProbe:
-{{ toYaml . | nindent 12 }}
+{{ omit .Values.livenessProbe "enabled" | toYaml | nindent 12 }}
 {{- end }}
-{{- with .Values.readinessProbe }}
+{{- if .Values.readinessProbe.enabled }}
           readinessProbe:
-{{ toYaml . | nindent 12 }}
+{{ omit .Values.readinessProbe "enabled" | toYaml | nindent 12 }}
 {{- end }}
-{{- with .Values.startupProbe }}
+{{- if .Values.startupProbe.enabled }}
           startupProbe:
-{{ toYaml . | nindent 12 }}
+{{ omit .Values.startupProbe "enabled" | toYaml | nindent 12 }}
 {{- end }}
 {{- if or .Values.configMounts .Values.extraVolumeMounts }}
           volumeMounts:
 {{- if .Values.configMounts }}
-{{ include "service-base.configMounts" . | nindent 12 }}
+{{ include "service-base.config" . | nindent 12 }}
 {{- end }}
-{{- if .Values.extraVolumeMounts }}
-{{ toYaml .Values.extraVolumeMounts | nindent 12 }}
+{{- $extraVolumeMounts := include "service-base.renderExtraVolumeMounts" . }}
+{{- if $extraVolumeMounts }}
+{{ $extraVolumeMounts | nindent 12 }}
 {{- end }}
+{{- end }}
+{{- if .Values.extraContainers }}
+{{ toYaml .Values.extraContainers | nindent 8 }}
 {{- end }}
 {{- if or .Values.configMounts .Values.extraVolumes }}
       volumes:
 {{- if .Values.configMounts }}
 {{ include "service-base.configVolumes" . | nindent 8 }}
 {{- end }}
-{{- if .Values.extraVolumes }}
-{{ toYaml .Values.extraVolumes | nindent 8 }}
+{{- $extraVolumes := include "service-base.renderExtraVolumes" . }}
+{{- if $extraVolumes }}
+{{ $extraVolumes | nindent 8 }}
 {{- end }}
+{{- end }}
+{{- if .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+{{ toYaml .Values.topologySpreadConstraints | nindent 8 }}
 {{- end }}
 {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/service-base/templates/_helpers.tpl
+++ b/charts/service-base/templates/_helpers.tpl
@@ -54,7 +54,13 @@ default
 {{- end -}}
 
 {{- define "service-base.image" -}}
+{{- $registry := default .Values.global.imageRegistry .Values.image.registry -}}
+{{- $registry = trimSuffix "/" $registry -}}
+{{- if $registry -}}
+{{- printf "%s/%s:%s" $registry .Values.image.repository (include "service-base.imageTag" .) -}}
+{{- else -}}
 {{- printf "%s:%s" .Values.image.repository (include "service-base.imageTag" .) -}}
+{{- end -}}
 {{- end -}}
 
 {{- define "service-base.imagePullSecrets" -}}
@@ -80,27 +86,94 @@ imagePullSecrets:
 {{- end }}
 {{- end -}}
 
+{{- define "service-base.config" -}}
+{{- include "service-base.configVolumeMounts" . -}}
+{{- end -}}
+
 {{- define "service-base.configMounts" -}}
 {{- include "service-base.configVolumeMounts" . -}}
 {{- end -}}
 
 {{- define "service-base.configVolumes" -}}
 {{- range .Values.configMounts }}
+{{- $sourceName := required "configMounts[].sourceName is required" .sourceName -}}
 - name: {{ .name }}
   {{- if eq (default "configMap" .type) "secret" }}
   secret:
-    secretName: {{ .name }}
+    secretName: {{ $sourceName }}
     {{- if .items }}
     items:
 {{ toYaml .items | nindent 6 }}
     {{- end }}
   {{- else }}
   configMap:
-    name: {{ .name }}
+    name: {{ $sourceName }}
     {{- if .items }}
     items:
 {{ toYaml .items | nindent 6 }}
     {{- end }}
   {{- end }}
+{{- end }}
+{{- end -}}
+
+{{- define "service-base.commonAnnotations" -}}
+{{- $annotations := dict -}}
+{{- with .Values.commonAnnotations }}
+{{- $annotations = merge $annotations . -}}
+{{- end }}
+{{- with .Values.deploymentAnnotations }}
+{{- $annotations = merge $annotations . -}}
+{{- end }}
+{{- if $annotations }}
+{{ toYaml $annotations }}
+{{- end }}
+{{- end -}}
+
+{{- define "service-base.renderEnv" -}}
+{{- $env := concat (.Values.env | default (list)) (.Values.extraEnvVars | default (list)) -}}
+{{- if $env }}
+env:
+{{ toYaml $env | nindent 2 }}
+{{- end }}
+{{- end -}}
+
+{{- define "service-base.renderEnvFrom" -}}
+{{- $envFrom := list -}}
+{{- if .Values.envFrom }}
+{{- $envFrom = concat $envFrom .Values.envFrom -}}
+{{- end }}
+{{- if .Values.extraEnvVarsCM }}
+{{- $envFrom = append $envFrom (dict "configMapRef" (dict "name" .Values.extraEnvVarsCM)) -}}
+{{- end }}
+{{- if .Values.extraEnvVarsSecret }}
+{{- $envFrom = append $envFrom (dict "secretRef" (dict "name" .Values.extraEnvVarsSecret)) -}}
+{{- end }}
+{{- if $envFrom }}
+envFrom:
+{{ toYaml $envFrom | nindent 2 }}
+{{- end }}
+{{- end -}}
+
+{{- define "service-base.renderExtraVolumes" -}}
+{{- if .Values.extraVolumes }}
+{{ toYaml .Values.extraVolumes }}
+{{- end }}
+{{- end -}}
+
+{{- define "service-base.renderExtraVolumeMounts" -}}
+{{- if .Values.extraVolumeMounts }}
+{{ toYaml .Values.extraVolumeMounts }}
+{{- end }}
+{{- end -}}
+
+{{- define "service-base.podSecurityContext" -}}
+{{- with .Values.podSecurityContext }}
+{{ toYaml . }}
+{{- end }}
+{{- end -}}
+
+{{- define "service-base.securityContext" -}}
+{{- with .Values.containerSecurityContext }}
+{{ toYaml . }}
 {{- end }}
 {{- end -}}

--- a/charts/service-base/templates/_helpers.tpl
+++ b/charts/service-base/templates/_helpers.tpl
@@ -54,7 +54,12 @@ default
 {{- end -}}
 
 {{- define "service-base.image" -}}
-{{- $registry := default .Values.global.imageRegistry .Values.image.registry -}}
+{{- $registry := "" -}}
+{{- if .Values.global.imageRegistry -}}
+{{- $registry = .Values.global.imageRegistry -}}
+{{- else -}}
+{{- $registry = .Values.image.registry -}}
+{{- end -}}
 {{- $registry = trimSuffix "/" $registry -}}
 {{- if $registry -}}
 {{- printf "%s/%s:%s" $registry .Values.image.repository (include "service-base.imageTag" .) -}}
@@ -173,7 +178,7 @@ envFrom:
 {{- end -}}
 
 {{- define "service-base.securityContext" -}}
-{{- with .Values.containerSecurityContext }}
-{{ toYaml . }}
+{{- if .Values.securityContext.enabled }}
+{{ omit .Values.securityContext "enabled" | toYaml }}
 {{- end }}
 {{- end -}}

--- a/charts/service-base/templates/_helpers.tpl
+++ b/charts/service-base/templates/_helpers.tpl
@@ -1,0 +1,106 @@
+{{- define "service-base.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "service-base.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "service-base.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" -}}
+{{- end -}}
+
+{{- define "service-base.labels" -}}
+helm.sh/chart: {{ include "service-base.chart" . }}
+{{ include "service-base.selectorLabels" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+{{- end -}}
+
+{{- define "service-base.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "service-base.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "service-base.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- if .Values.serviceAccount.name -}}
+{{- .Values.serviceAccount.name -}}
+{{- else -}}
+{{- include "service-base.fullname" . -}}
+{{- end -}}
+{{- else -}}
+{{- if .Values.serviceAccount.name -}}
+{{- .Values.serviceAccount.name -}}
+{{- else -}}
+default
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "service-base.imageTag" -}}
+{{- if .Values.image.tag -}}
+{{- .Values.image.tag -}}
+{{- else -}}
+{{- .Chart.AppVersion -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "service-base.image" -}}
+{{- printf "%s:%s" .Values.image.repository (include "service-base.imageTag" .) -}}
+{{- end -}}
+
+{{- define "service-base.imagePullSecrets" -}}
+{{- $globalSecrets := .Values.global.imagePullSecrets | default (list) -}}
+{{- $imageSecrets := .Values.image.pullSecrets | default (list) -}}
+{{- $pullSecrets := concat $globalSecrets $imageSecrets | uniq -}}
+{{- if $pullSecrets }}
+imagePullSecrets:
+{{- range $secret := $pullSecrets }}
+  - name: {{ $secret }}
+{{- end }}
+{{- end }}
+{{- end -}}
+
+{{- define "service-base.configVolumeMounts" -}}
+{{- range .Values.configMounts }}
+- name: {{ .name }}
+  mountPath: {{ .mountPath }}
+  {{- if .subPath }}
+  subPath: {{ .subPath }}
+  {{- end }}
+  readOnly: {{ .readOnly | default true }}
+{{- end }}
+{{- end -}}
+
+{{- define "service-base.configMounts" -}}
+{{- include "service-base.configVolumeMounts" . -}}
+{{- end -}}
+
+{{- define "service-base.configVolumes" -}}
+{{- range .Values.configMounts }}
+- name: {{ .name }}
+  {{- if eq (default "configMap" .type) "secret" }}
+  secret:
+    secretName: {{ .name }}
+    {{- if .items }}
+    items:
+{{ toYaml .items | nindent 6 }}
+    {{- end }}
+  {{- else }}
+  configMap:
+    name: {{ .name }}
+    {{- if .items }}
+    items:
+{{ toYaml .items | nindent 6 }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+{{- end -}}

--- a/charts/service-base/templates/_helpers.tpl
+++ b/charts/service-base/templates/_helpers.tpl
@@ -172,8 +172,8 @@ envFrom:
 {{- end -}}
 
 {{- define "service-base.podSecurityContext" -}}
-{{- with .Values.podSecurityContext }}
-{{ toYaml . }}
+{{- if .Values.podSecurityContext.enabled }}
+{{ omit .Values.podSecurityContext "enabled" | toYaml }}
 {{- end }}
 {{- end -}}
 

--- a/charts/service-base/templates/_hpa.tpl
+++ b/charts/service-base/templates/_hpa.tpl
@@ -1,0 +1,43 @@
+{{- define "service-base.hpa" -}}
+{{- if .Values.autoscaling.enabled -}}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "service-base.fullname" . }}
+  labels:
+{{ include "service-base.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "service-base.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+{{- if .Values.autoscaling.metrics }}
+  metrics:
+{{ toYaml .Values.autoscaling.metrics | nindent 4 }}
+{{- else }}
+  metrics:
+{{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+{{- end }}
+{{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+{{- end }}
+{{- end }}
+{{- with .Values.autoscaling.behavior }}
+  behavior:
+{{ toYaml . | nindent 4 }}
+{{- end }}
+{{- end -}}
+{{- end -}}

--- a/charts/service-base/templates/_ingress.tpl
+++ b/charts/service-base/templates/_ingress.tpl
@@ -11,8 +11,8 @@ metadata:
 {{ toYaml . | nindent 4 }}
 {{- end }}
 spec:
-{{- if .Values.ingress.className }}
-  ingressClassName: {{ .Values.ingress.className }}
+{{- if .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
 {{- end }}
 {{- if .Values.ingress.tls }}
   tls:

--- a/charts/service-base/templates/_ingress.tpl
+++ b/charts/service-base/templates/_ingress.tpl
@@ -1,0 +1,41 @@
+{{- define "service-base.ingress" -}}
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "service-base.fullname" . }}
+  labels:
+{{ include "service-base.labels" . | nindent 4 }}
+{{- with .Values.ingress.annotations }}
+  annotations:
+{{ toYaml . | nindent 4 }}
+{{- end }}
+spec:
+{{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+{{- end }}
+{{- if .Values.ingress.tls }}
+  tls:
+{{ toYaml .Values.ingress.tls | nindent 4 }}
+{{- end }}
+  rules:
+{{- range .Values.ingress.hosts }}
+    - host: {{ .host }}
+      http:
+        paths:
+{{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "service-base.fullname" $ }}
+                port:
+                  {{- if kindIs "int" .servicePort }}
+                  number: {{ .servicePort }}
+                  {{- else }}
+                  name: {{ .servicePort }}
+                  {{- end }}
+{{- end }}
+{{- end }}
+{{- end -}}
+{{- end -}}

--- a/charts/service-base/templates/_pdb.tpl
+++ b/charts/service-base/templates/_pdb.tpl
@@ -1,0 +1,19 @@
+{{- define "service-base.pdb" -}}
+{{- if .Values.pdb.enabled -}}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "service-base.fullname" . }}
+  labels:
+{{ include "service-base.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+{{ include "service-base.selectorLabels" . | nindent 6 }}
+{{- if .Values.pdb.minAvailable }}
+  minAvailable: {{ .Values.pdb.minAvailable }}
+{{- else if .Values.pdb.maxUnavailable }}
+  maxUnavailable: {{ .Values.pdb.maxUnavailable }}
+{{- end }}
+{{- end -}}
+{{- end -}}

--- a/charts/service-base/templates/_rbac.tpl
+++ b/charts/service-base/templates/_rbac.tpl
@@ -1,0 +1,27 @@
+{{- define "service-base.rbac" -}}
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: {{ ternary "ClusterRole" "Role" .Values.rbac.clusterWide }}
+metadata:
+  name: {{ include "service-base.fullname" . }}
+  labels:
+{{ include "service-base.labels" . | nindent 4 }}
+rules:
+{{ toYaml .Values.rbac.rules | nindent 2 }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: {{ ternary "ClusterRoleBinding" "RoleBinding" .Values.rbac.clusterWide }}
+metadata:
+  name: {{ include "service-base.fullname" . }}
+  labels:
+{{ include "service-base.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "service-base.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: {{ ternary "ClusterRole" "Role" .Values.rbac.clusterWide }}
+  name: {{ include "service-base.fullname" . }}
+{{- end -}}
+{{- end -}}

--- a/charts/service-base/templates/_service.tpl
+++ b/charts/service-base/templates/_service.tpl
@@ -1,0 +1,29 @@
+{{- define "service-base.service" -}}
+{{- if .Values.service.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "service-base.fullname" . }}
+  labels:
+{{ include "service-base.labels" . | nindent 4 }}
+{{- with .Values.service.annotations }}
+  annotations:
+{{ toYaml . | nindent 4 }}
+{{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+{{ include "service-base.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: {{ .Values.service.portName }}
+      port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.targetPort }}
+      protocol: TCP
+{{- range .Values.service.additionalPorts }}
+    - name: {{ .name }}
+      port: {{ .port }}
+      targetPort: {{ .targetPort }}
+      protocol: {{ .protocol | default "TCP" }}
+{{- end }}
+{{- end -}}
+{{- end -}}

--- a/charts/service-base/templates/_service.tpl
+++ b/charts/service-base/templates/_service.tpl
@@ -15,11 +15,7 @@ spec:
   selector:
 {{ include "service-base.selectorLabels" . | nindent 4 }}
   ports:
-    - name: {{ .Values.service.portName }}
-      port: {{ .Values.service.port }}
-      targetPort: {{ .Values.service.targetPort }}
-      protocol: TCP
-{{- range .Values.service.additionalPorts }}
+{{- range .Values.service.ports }}
     - name: {{ .name }}
       port: {{ .port }}
       targetPort: {{ .targetPort }}

--- a/charts/service-base/templates/_service.tpl
+++ b/charts/service-base/templates/_service.tpl
@@ -6,6 +6,9 @@ metadata:
   name: {{ include "service-base.fullname" . }}
   labels:
 {{ include "service-base.labels" . | nindent 4 }}
+{{- with .Values.service.labels }}
+{{ toYaml . | nindent 4 }}
+{{- end }}
 {{- with .Values.service.annotations }}
   annotations:
 {{ toYaml . | nindent 4 }}

--- a/charts/service-base/templates/_serviceaccount.tpl
+++ b/charts/service-base/templates/_serviceaccount.tpl
@@ -1,0 +1,14 @@
+{{- define "service-base.serviceAccount" -}}
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "service-base.serviceAccountName" . }}
+  labels:
+{{ include "service-base.labels" . | nindent 4 }}
+{{- with .Values.serviceAccount.annotations }}
+  annotations:
+{{ toYaml . | nindent 4 }}
+{{- end }}
+{{- end -}}
+{{- end -}}

--- a/charts/service-base/templates/metrics/_servicemonitor.tpl
+++ b/charts/service-base/templates/metrics/_servicemonitor.tpl
@@ -1,4 +1,4 @@
-{{- define "service-base.servicemonitor" -}}
+{{- define "service-base.metrics" -}}
 {{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") -}}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
@@ -6,7 +6,11 @@ metadata:
   name: {{ include "service-base.fullname" . }}
   labels:
 {{ include "service-base.labels" . | nindent 4 }}
-{{- with .Values.metrics.serviceMonitor.additionalLabels }}
+{{- with .Values.metrics.serviceMonitor.labels }}
+{{ toYaml . | nindent 4 }}
+{{- end }}
+{{- with .Values.metrics.serviceMonitor.annotations }}
+  annotations:
 {{ toYaml . | nindent 4 }}
 {{- end }}
 {{- if .Values.metrics.serviceMonitor.namespace }}
@@ -16,9 +20,11 @@ spec:
   selector:
     matchLabels:
 {{ include "service-base.selectorLabels" . | nindent 6 }}
+  {{- if and .Values.metrics.serviceMonitor.namespace (ne .Values.metrics.serviceMonitor.namespace .Release.Namespace) }}
   namespaceSelector:
     matchNames:
-      - {{ .Release.Namespace }}
+      - {{ .Values.metrics.serviceMonitor.namespace }}
+  {{- end }}
   endpoints:
 {{- range .Values.metrics.serviceMonitor.endpoints }}
     - port: {{ .port }}

--- a/charts/service-base/templates/metrics/_servicemonitor.tpl
+++ b/charts/service-base/templates/metrics/_servicemonitor.tpl
@@ -1,0 +1,45 @@
+{{- define "service-base.servicemonitor" -}}
+{{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") -}}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "service-base.fullname" . }}
+  labels:
+{{ include "service-base.labels" . | nindent 4 }}
+{{- with .Values.metrics.serviceMonitor.additionalLabels }}
+{{ toYaml . | nindent 4 }}
+{{- end }}
+{{- if .Values.metrics.serviceMonitor.namespace }}
+  namespace: {{ .Values.metrics.serviceMonitor.namespace }}
+{{- end }}
+spec:
+  selector:
+    matchLabels:
+{{ include "service-base.selectorLabels" . | nindent 6 }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  endpoints:
+{{- range .Values.metrics.serviceMonitor.endpoints }}
+    - port: {{ .port }}
+      path: {{ .path | default "/metrics" }}
+      {{- $interval := default $.Values.metrics.serviceMonitor.interval .interval }}
+      {{- if $interval }}
+      interval: {{ $interval }}
+      {{- end }}
+      {{- $scrapeTimeout := default $.Values.metrics.serviceMonitor.scrapeTimeout .scrapeTimeout }}
+      {{- if $scrapeTimeout }}
+      scrapeTimeout: {{ $scrapeTimeout }}
+      {{- end }}
+      honorLabels: {{ $.Values.metrics.serviceMonitor.honorLabels }}
+      {{- with $.Values.metrics.serviceMonitor.relabelings }}
+      relabelings:
+{{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $.Values.metrics.serviceMonitor.metricRelabelings }}
+      metricRelabelings:
+{{ toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}
+{{- end -}}
+{{- end -}}

--- a/charts/service-base/values.schema.json
+++ b/charts/service-base/values.schema.json
@@ -11,10 +11,21 @@
       "type": "string",
       "default": ""
     },
+    "commonAnnotations": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      },
+      "default": {}
+    },
     "global": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "imageRegistry": {
+          "type": "string",
+          "default": ""
+        },
         "imagePullSecrets": {
           "type": "array",
           "items": {
@@ -24,6 +35,7 @@
         }
       },
       "default": {
+        "imageRegistry": "",
         "imagePullSecrets": []
       }
     },
@@ -32,6 +44,10 @@
       "additionalProperties": false,
       "required": ["repository"],
       "properties": {
+        "registry": {
+          "type": "string",
+          "default": ""
+        },
         "repository": {
           "type": "string",
           "minLength": 1,
@@ -55,6 +71,7 @@
         }
       },
       "default": {
+        "registry": "",
         "repository": "",
         "tag": "",
         "pullPolicy": "IfNotPresent",
@@ -70,6 +87,17 @@
       "type": "integer",
       "minimum": 0,
       "default": 10
+    },
+    "updateStrategy": {
+      "type": "object",
+      "default": {}
+    },
+    "deploymentAnnotations": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      },
+      "default": {}
     },
     "podAnnotations": {
       "type": "object",
@@ -194,31 +222,6 @@
           "type": "string",
           "default": "ClusterIP"
         },
-        "port": {
-          "type": "integer",
-          "minimum": 1,
-          "maximum": 65535,
-          "default": 80
-        },
-        "portName": {
-          "type": "string",
-          "minLength": 1,
-          "default": "http"
-        },
-        "targetPort": {
-          "oneOf": [
-            {
-              "type": "integer",
-              "minimum": 1,
-              "maximum": 65535
-            },
-            {
-              "type": "string",
-              "minLength": 1
-            }
-          ],
-          "default": "http"
-        },
         "annotations": {
           "type": "object",
           "additionalProperties": {
@@ -226,14 +229,16 @@
           },
           "default": {}
         },
-        "additionalPorts": {
+        "ports": {
           "type": "array",
+          "minItems": 1,
           "items": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
               "name": {
-                "type": "string"
+                "type": "string",
+                "minLength": 1
               },
               "port": {
                 "type": "integer",
@@ -260,17 +265,28 @@
             },
             "required": ["name", "port", "targetPort"]
           },
-          "default": []
+          "default": [
+            {
+              "name": "http",
+              "port": 80,
+              "targetPort": "http",
+              "protocol": "TCP"
+            }
+          ]
         }
       },
       "default": {
         "enabled": true,
         "type": "ClusterIP",
-        "port": 80,
-        "portName": "http",
-        "targetPort": "http",
         "annotations": {},
-        "additionalPorts": []
+        "ports": [
+          {
+            "name": "http",
+            "port": 80,
+            "targetPort": "http",
+            "protocol": "TCP"
+          }
+        ]
       }
     },
     "containerPorts": {
@@ -321,17 +337,74 @@
       "type": "object",
       "default": {}
     },
+    "priorityClassName": {
+      "type": "string",
+      "default": ""
+    },
+    "terminationGracePeriodSeconds": {
+      "type": ["integer", "null"],
+      "minimum": 0,
+      "default": null
+    },
+    "topologySpreadConstraints": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      },
+      "default": []
+    },
+    "initContainers": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      },
+      "default": []
+    },
+    "extraContainers": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      },
+      "default": []
+    },
     "livenessProbe": {
       "type": "object",
-      "default": {}
+      "additionalProperties": true,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "default": {
+        "enabled": false
+      }
     },
     "readinessProbe": {
       "type": "object",
-      "default": {}
+      "additionalProperties": true,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "default": {
+        "enabled": false
+      }
     },
     "startupProbe": {
       "type": "object",
-      "default": {}
+      "additionalProperties": true,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "default": {
+        "enabled": false
+      }
     },
     "command": {
       "type": "array",
@@ -361,6 +434,21 @@
       },
       "default": []
     },
+    "extraEnvVars": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      },
+      "default": []
+    },
+    "extraEnvVarsCM": {
+      "type": "string",
+      "default": ""
+    },
+    "extraEnvVarsSecret": {
+      "type": "string",
+      "default": ""
+    },
     "configMounts": {
       "type": "array",
       "items": {
@@ -368,6 +456,10 @@
         "additionalProperties": false,
         "properties": {
           "name": {
+            "type": "string",
+            "minLength": 1
+          },
+          "sourceName": {
             "type": "string",
             "minLength": 1
           },
@@ -404,7 +496,7 @@
             }
           }
         },
-        "required": ["name", "mountPath"]
+        "required": ["name", "sourceName", "mountPath"]
       },
       "default": []
     },
@@ -574,7 +666,7 @@
           "type": "boolean",
           "default": false
         },
-        "className": {
+        "ingressClassName": {
           "type": "string",
           "default": ""
         },
@@ -655,7 +747,7 @@
       },
       "default": {
         "enabled": false,
-        "className": "",
+        "ingressClassName": "",
         "annotations": {},
         "hosts": [
           {
@@ -704,7 +796,14 @@
               "type": "boolean",
               "default": false
             },
-            "additionalLabels": {
+            "labels": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "default": {}
+            },
+            "annotations": {
               "type": "object",
               "additionalProperties": {
                 "type": "string"
@@ -767,7 +866,8 @@
             "interval": "",
             "scrapeTimeout": "",
             "honorLabels": false,
-            "additionalLabels": {},
+            "labels": {},
+            "annotations": {},
             "relabelings": [],
             "metricRelabelings": [],
             "endpoints": [
@@ -789,7 +889,8 @@
           "interval": "",
           "scrapeTimeout": "",
           "honorLabels": false,
-          "additionalLabels": {},
+          "labels": {},
+          "annotations": {},
           "relabelings": [],
           "metricRelabelings": [],
           "endpoints": [

--- a/charts/service-base/values.schema.json
+++ b/charts/service-base/values.schema.json
@@ -1,0 +1,807 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "nameOverride": {
+      "type": "string",
+      "default": ""
+    },
+    "fullnameOverride": {
+      "type": "string",
+      "default": ""
+    },
+    "global": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "imagePullSecrets": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": []
+        }
+      },
+      "default": {
+        "imagePullSecrets": []
+      }
+    },
+    "image": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["repository"],
+      "properties": {
+        "repository": {
+          "type": "string",
+          "minLength": 1,
+          "default": ""
+        },
+        "tag": {
+          "type": "string",
+          "default": ""
+        },
+        "pullPolicy": {
+          "type": "string",
+          "enum": ["Always", "IfNotPresent", "Never"],
+          "default": "IfNotPresent"
+        },
+        "pullSecrets": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": []
+        }
+      },
+      "default": {
+        "repository": "",
+        "tag": "",
+        "pullPolicy": "IfNotPresent",
+        "pullSecrets": []
+      }
+    },
+    "replicaCount": {
+      "type": "integer",
+      "minimum": 1,
+      "default": 1
+    },
+    "revisionHistoryLimit": {
+      "type": "integer",
+      "minimum": 0,
+      "default": 10
+    },
+    "podAnnotations": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      },
+      "default": {}
+    },
+    "podLabels": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      },
+      "default": {}
+    },
+    "podSecurityContext": {
+      "type": "object",
+      "default": {}
+    },
+    "containerSecurityContext": {
+      "type": "object",
+      "default": {}
+    },
+    "serviceAccount": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "create": {
+          "type": "boolean",
+          "default": true
+        },
+        "name": {
+          "type": "string",
+          "default": ""
+        },
+        "annotations": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "default": {}
+        }
+      },
+      "default": {
+        "create": true,
+        "name": "",
+        "annotations": {}
+      }
+    },
+    "automountServiceAccountToken": {
+      "type": "boolean",
+      "default": true
+    },
+    "rbac": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "create": {
+          "type": "boolean",
+          "default": false
+        },
+        "clusterWide": {
+          "type": "boolean",
+          "default": false
+        },
+        "rules": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "apiGroups": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "resources": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "resourceNames": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "verbs": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "nonResourceURLs": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            "required": ["verbs"]
+          },
+          "default": []
+        }
+      },
+      "default": {
+        "create": false,
+        "clusterWide": false,
+        "rules": []
+      }
+    },
+    "service": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "default": true
+        },
+        "type": {
+          "type": "string",
+          "default": "ClusterIP"
+        },
+        "port": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535,
+          "default": 80
+        },
+        "portName": {
+          "type": "string",
+          "minLength": 1,
+          "default": "http"
+        },
+        "targetPort": {
+          "oneOf": [
+            {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 65535
+            },
+            {
+              "type": "string",
+              "minLength": 1
+            }
+          ],
+          "default": "http"
+        },
+        "annotations": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "default": {}
+        },
+        "additionalPorts": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "port": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 65535
+              },
+              "targetPort": {
+                "oneOf": [
+                  {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 65535
+                  },
+                  {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                ]
+              },
+              "protocol": {
+                "type": "string",
+                "default": "TCP"
+              }
+            },
+            "required": ["name", "port", "targetPort"]
+          },
+          "default": []
+        }
+      },
+      "default": {
+        "enabled": true,
+        "type": "ClusterIP",
+        "port": 80,
+        "portName": "http",
+        "targetPort": "http",
+        "annotations": {},
+        "additionalPorts": []
+      }
+    },
+    "containerPorts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "containerPort": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 65535
+          },
+          "protocol": {
+            "type": "string",
+            "default": "TCP"
+          }
+        },
+        "required": ["name", "containerPort"]
+      },
+      "default": [
+        {
+          "name": "http",
+          "containerPort": 8080,
+          "protocol": "TCP"
+        }
+      ]
+    },
+    "resources": {
+      "type": "object",
+      "default": {}
+    },
+    "nodeSelector": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      },
+      "default": {}
+    },
+    "tolerations": {
+      "type": "array",
+      "default": []
+    },
+    "affinity": {
+      "type": "object",
+      "default": {}
+    },
+    "livenessProbe": {
+      "type": "object",
+      "default": {}
+    },
+    "readinessProbe": {
+      "type": "object",
+      "default": {}
+    },
+    "startupProbe": {
+      "type": "object",
+      "default": {}
+    },
+    "command": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "default": []
+    },
+    "args": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "default": []
+    },
+    "env": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      },
+      "default": []
+    },
+    "envFrom": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      },
+      "default": []
+    },
+    "configMounts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1
+          },
+          "type": {
+            "type": "string",
+            "enum": ["configMap", "secret"],
+            "default": "configMap"
+          },
+          "mountPath": {
+            "type": "string",
+            "minLength": 1
+          },
+          "subPath": {
+            "type": "string"
+          },
+          "readOnly": {
+            "type": "boolean",
+            "default": true
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "key": {
+                  "type": "string"
+                },
+                "path": {
+                  "type": "string"
+                }
+              },
+              "required": ["key", "path"]
+            }
+          }
+        },
+        "required": ["name", "mountPath"]
+      },
+      "default": []
+    },
+    "extraVolumeMounts": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      },
+      "default": []
+    },
+    "extraVolumes": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      },
+      "default": []
+    },
+    "autoscaling": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "default": false
+        },
+        "minReplicas": {
+          "type": "integer",
+          "minimum": 1,
+          "default": 1
+        },
+        "maxReplicas": {
+          "type": "integer",
+          "minimum": 1,
+          "default": 3
+        },
+        "targetCPUUtilizationPercentage": {
+          "type": ["integer", "null"],
+          "minimum": 1,
+          "maximum": 100,
+          "default": 80
+        },
+        "targetMemoryUtilizationPercentage": {
+          "type": ["integer", "null"],
+          "minimum": 1,
+          "maximum": 100,
+          "default": null
+        },
+        "metrics": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          },
+          "default": []
+        },
+        "behavior": {
+          "type": "object",
+          "default": {}
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "enabled": {
+                "const": true
+              }
+            },
+            "required": ["enabled"]
+          },
+          "then": {
+            "required": ["minReplicas", "maxReplicas"],
+            "anyOf": [
+              {
+                "required": ["targetCPUUtilizationPercentage"]
+              },
+              {
+                "required": ["targetMemoryUtilizationPercentage"]
+              },
+              {
+                "properties": {
+                  "metrics": {
+                    "minItems": 1
+                  }
+                },
+                "required": ["metrics"]
+              }
+            ]
+          }
+        }
+      ],
+      "default": {
+        "enabled": false,
+        "minReplicas": 1,
+        "maxReplicas": 3,
+        "targetCPUUtilizationPercentage": 80,
+        "targetMemoryUtilizationPercentage": null,
+        "metrics": [],
+        "behavior": {}
+      }
+    },
+    "pdb": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "default": false
+        },
+        "minAvailable": {
+          "type": ["integer", "string", "null"],
+          "default": null
+        },
+        "maxUnavailable": {
+          "type": ["integer", "string", "null"],
+          "default": null
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "enabled": {
+                "const": true
+              }
+            },
+            "required": ["enabled"]
+          },
+          "then": {
+            "oneOf": [
+              {
+                "required": ["minAvailable"],
+                "properties": {
+                  "minAvailable": {
+                    "type": ["integer", "string"]
+                  },
+                  "maxUnavailable": {
+                    "type": "null"
+                  }
+                }
+              },
+              {
+                "required": ["maxUnavailable"],
+                "properties": {
+                  "maxUnavailable": {
+                    "type": ["integer", "string"]
+                  },
+                  "minAvailable": {
+                    "type": "null"
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "default": {
+        "enabled": false,
+        "minAvailable": null,
+        "maxUnavailable": null
+      }
+    },
+    "ingress": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "default": false
+        },
+        "className": {
+          "type": "string",
+          "default": ""
+        },
+        "annotations": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "default": {}
+        },
+        "hosts": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "host": {
+                "type": "string",
+                "minLength": 1
+              },
+              "paths": {
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "path": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "pathType": {
+                      "type": "string",
+                      "enum": ["Exact", "Prefix", "ImplementationSpecific"]
+                    },
+                    "servicePort": {
+                      "oneOf": [
+                        {
+                          "type": "integer",
+                          "minimum": 1,
+                          "maximum": 65535
+                        },
+                        {
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      ],
+                      "default": "http"
+                    }
+                  },
+                  "required": ["path", "pathType"]
+                }
+              }
+            },
+            "required": ["host", "paths"]
+          },
+          "default": [
+            {
+              "host": "chart-example.local",
+              "paths": [
+                {
+                  "path": "/",
+                  "pathType": "Prefix",
+                  "servicePort": "http"
+                }
+              ]
+            }
+          ]
+        },
+        "tls": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          },
+          "default": []
+        }
+      },
+      "default": {
+        "enabled": false,
+        "className": "",
+        "annotations": {},
+        "hosts": [
+          {
+            "host": "chart-example.local",
+            "paths": [
+              {
+                "path": "/",
+                "pathType": "Prefix",
+                "servicePort": "http"
+              }
+            ]
+          }
+        ],
+        "tls": []
+      }
+    },
+    "metrics": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "default": false
+        },
+        "serviceMonitor": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "default": false
+            },
+            "namespace": {
+              "type": "string",
+              "default": ""
+            },
+            "interval": {
+              "type": "string",
+              "default": ""
+            },
+            "scrapeTimeout": {
+              "type": "string",
+              "default": ""
+            },
+            "honorLabels": {
+              "type": "boolean",
+              "default": false
+            },
+            "additionalLabels": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "default": {}
+            },
+            "relabelings": {
+              "type": "array",
+              "items": {
+                "type": "object"
+              },
+              "default": []
+            },
+            "metricRelabelings": {
+              "type": "array",
+              "items": {
+                "type": "object"
+              },
+              "default": []
+            },
+            "endpoints": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "port": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "path": {
+                    "type": "string",
+                    "default": "/metrics"
+                  },
+                  "interval": {
+                    "type": "string",
+                    "default": ""
+                  },
+                  "scrapeTimeout": {
+                    "type": "string",
+                    "default": ""
+                  }
+                },
+                "required": ["port"]
+              },
+              "default": [
+                {
+                  "port": "http",
+                  "path": "/metrics",
+                  "interval": "",
+                  "scrapeTimeout": ""
+                }
+              ]
+            }
+          },
+          "default": {
+            "enabled": false,
+            "namespace": "",
+            "interval": "",
+            "scrapeTimeout": "",
+            "honorLabels": false,
+            "additionalLabels": {},
+            "relabelings": [],
+            "metricRelabelings": [],
+            "endpoints": [
+              {
+                "port": "http",
+                "path": "/metrics",
+                "interval": "",
+                "scrapeTimeout": ""
+              }
+            ]
+          }
+        }
+      },
+      "default": {
+        "enabled": false,
+        "serviceMonitor": {
+          "enabled": false,
+          "namespace": "",
+          "interval": "",
+          "scrapeTimeout": "",
+          "honorLabels": false,
+          "additionalLabels": {},
+          "relabelings": [],
+          "metricRelabelings": [],
+          "endpoints": [
+            {
+              "port": "http",
+              "path": "/metrics",
+              "interval": "",
+              "scrapeTimeout": ""
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/charts/service-base/values.schema.json
+++ b/charts/service-base/values.schema.json
@@ -115,7 +115,22 @@
     },
     "podSecurityContext": {
       "type": "object",
-      "default": {}
+      "additionalProperties": true,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "default": false
+        },
+        "fsGroup": {
+          "type": ["integer", "null"],
+          "minimum": 0,
+          "default": null
+        }
+      },
+      "default": {
+        "enabled": false,
+        "fsGroup": null
+      }
     },
     "securityContext": {
       "type": "object",

--- a/charts/service-base/values.schema.json
+++ b/charts/service-base/values.schema.json
@@ -117,9 +117,27 @@
       "type": "object",
       "default": {}
     },
-    "containerSecurityContext": {
+    "securityContext": {
       "type": "object",
-      "default": {}
+      "additionalProperties": true,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "default": true
+        }
+      },
+      "default": {
+        "enabled": true,
+        "runAsNonRoot": true,
+        "readOnlyRootFilesystem": true,
+        "allowPrivilegeEscalation": false,
+        "capabilities": {
+          "drop": ["ALL"]
+        },
+        "seccompProfile": {
+          "type": "RuntimeDefault"
+        }
+      }
     },
     "serviceAccount": {
       "type": "object",
@@ -229,6 +247,13 @@
           },
           "default": {}
         },
+        "labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "default": {}
+        },
         "ports": {
           "type": "array",
           "minItems": 1,
@@ -279,6 +304,7 @@
         "enabled": true,
         "type": "ClusterIP",
         "annotations": {},
+        "labels": {},
         "ports": [
           {
             "name": "http",
@@ -366,6 +392,10 @@
         "type": "object"
       },
       "default": []
+    },
+    "lifecycle": {
+      "type": "object",
+      "default": {}
     },
     "livenessProbe": {
       "type": "object",

--- a/charts/service-base/values.schema.json
+++ b/charts/service-base/values.schema.json
@@ -139,6 +139,48 @@
         "enabled": {
           "type": "boolean",
           "default": true
+        },
+        "runAsNonRoot": {
+          "type": "boolean",
+          "default": true
+        },
+        "readOnlyRootFilesystem": {
+          "type": "boolean",
+          "default": true
+        },
+        "allowPrivilegeEscalation": {
+          "type": "boolean",
+          "default": false
+        },
+        "capabilities": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "drop": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": ["ALL"]
+            }
+          },
+          "default": {
+            "drop": ["ALL"]
+          }
+        },
+        "seccompProfile": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": ["RuntimeDefault"],
+              "default": "RuntimeDefault"
+            }
+          },
+          "default": {
+            "type": "RuntimeDefault"
+          }
         }
       },
       "default": {

--- a/charts/service-base/values.yaml
+++ b/charts/service-base/values.yaml
@@ -1,0 +1,107 @@
+nameOverride: ""
+fullnameOverride: ""
+
+global:
+  imagePullSecrets: []
+
+image:
+  repository: ""
+  tag: ""
+  pullPolicy: IfNotPresent
+  pullSecrets: []
+
+replicaCount: 1
+revisionHistoryLimit: 10
+
+podAnnotations: {}
+podLabels: {}
+
+podSecurityContext: {}
+containerSecurityContext: {}
+
+serviceAccount:
+  create: true
+  name: ""
+  annotations: {}
+
+automountServiceAccountToken: true
+
+rbac:
+  create: false
+  clusterWide: false
+  rules: []
+
+service:
+  enabled: true
+  type: ClusterIP
+  port: 80
+  portName: http
+  targetPort: http
+  annotations: {}
+  additionalPorts: []
+
+containerPorts:
+  - name: http
+    containerPort: 8080
+    protocol: TCP
+
+resources: {}
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+livenessProbe: {}
+readinessProbe: {}
+startupProbe: {}
+
+command: []
+args: []
+env: []
+envFrom: []
+
+configMounts: []
+extraVolumeMounts: []
+extraVolumes: []
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 3
+  targetCPUUtilizationPercentage: 80
+  targetMemoryUtilizationPercentage: null
+  metrics: []
+  behavior: {}
+
+pdb:
+  enabled: false
+  minAvailable: null
+  maxUnavailable: null
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: Prefix
+          servicePort: http
+  tls: []
+
+metrics:
+  enabled: false
+  serviceMonitor:
+    enabled: false
+    namespace: ""
+    interval: ""
+    scrapeTimeout: ""
+    honorLabels: false
+    additionalLabels: {}
+    relabelings: []
+    metricRelabelings: []
+    endpoints:
+      - port: http
+        path: /metrics
+        interval: ""
+        scrapeTimeout: ""

--- a/charts/service-base/values.yaml
+++ b/charts/service-base/values.yaml
@@ -22,7 +22,9 @@ deploymentAnnotations: {}
 podAnnotations: {}
 podLabels: {}
 
-podSecurityContext: {}
+podSecurityContext:
+  enabled: false
+  fsGroup: null
 securityContext:
   enabled: true
   runAsNonRoot: true

--- a/charts/service-base/values.yaml
+++ b/charts/service-base/values.yaml
@@ -1,10 +1,14 @@
 nameOverride: ""
 fullnameOverride: ""
 
+commonAnnotations: {}
+
 global:
+  imageRegistry: ""
   imagePullSecrets: []
 
 image:
+  registry: ""
   repository: ""
   tag: ""
   pullPolicy: IfNotPresent
@@ -12,6 +16,8 @@ image:
 
 replicaCount: 1
 revisionHistoryLimit: 10
+updateStrategy: {}
+deploymentAnnotations: {}
 
 podAnnotations: {}
 podLabels: {}
@@ -34,11 +40,12 @@ rbac:
 service:
   enabled: true
   type: ClusterIP
-  port: 80
-  portName: http
-  targetPort: http
   annotations: {}
-  additionalPorts: []
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+      protocol: TCP
 
 containerPorts:
   - name: http
@@ -50,14 +57,27 @@ nodeSelector: {}
 tolerations: []
 affinity: {}
 
-livenessProbe: {}
-readinessProbe: {}
-startupProbe: {}
+priorityClassName: ""
+terminationGracePeriodSeconds: null
+topologySpreadConstraints: []
+
+initContainers: []
+extraContainers: []
+
+livenessProbe:
+  enabled: false
+readinessProbe:
+  enabled: false
+startupProbe:
+  enabled: false
 
 command: []
 args: []
 env: []
 envFrom: []
+extraEnvVars: []
+extraEnvVarsCM: ""
+extraEnvVarsSecret: ""
 
 configMounts: []
 extraVolumeMounts: []
@@ -79,7 +99,7 @@ pdb:
 
 ingress:
   enabled: false
-  className: ""
+  ingressClassName: ""
   annotations: {}
   hosts:
     - host: chart-example.local
@@ -97,7 +117,8 @@ metrics:
     interval: ""
     scrapeTimeout: ""
     honorLabels: false
-    additionalLabels: {}
+    labels: {}
+    annotations: {}
     relabelings: []
     metricRelabelings: []
     endpoints:

--- a/charts/service-base/values.yaml
+++ b/charts/service-base/values.yaml
@@ -23,7 +23,16 @@ podAnnotations: {}
 podLabels: {}
 
 podSecurityContext: {}
-containerSecurityContext: {}
+securityContext:
+  enabled: true
+  runAsNonRoot: true
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  seccompProfile:
+    type: RuntimeDefault
 
 serviceAccount:
   create: true
@@ -41,6 +50,7 @@ service:
   enabled: true
   type: ClusterIP
   annotations: {}
+  labels: {}
   ports:
     - name: http
       port: 80
@@ -63,6 +73,8 @@ topologySpreadConstraints: []
 
 initContainers: []
 extraContainers: []
+
+lifecycle: {}
 
 livenessProbe:
   enabled: false


### PR DESCRIPTION
## Summary
- add the service-base Helm library chart templates and helpers
- add values.yaml and values.schema.json enforcing required invariants
- add release workflow for GHCR OCI publishing
- document usage and values in chart README

## Testing
- helm lint charts/service-base --values /tmp/service-base-lint-values.yaml
- helm template service-base-consumer /tmp/service-base-consumer --values /tmp/service-base-values.yaml

## Notes
- Closes #1
- After merge, tag the repo with v0.1.0 to publish the chart.