### PR TITLE
fix: set default image repository

### DIFF
--- a/charts/service-base/README.md
+++ b/charts/service-base/README.md
@@ -44,6 +44,7 @@ Key values (see `values.yaml` for full list):
 
 - `image.repository` (required)
 - `image.tag` (defaults to `.Chart.AppVersion`)
+- `image.repository` defaults to a placeholder; consuming charts must override
 - `global.imageRegistry` and `image.registry` (registry resolution)
 - `global.imagePullSecrets` and `image.pullSecrets` (merged in PodSpec)
 - `service.ports[]` for service ports

--- a/charts/service-base/values.schema.json
+++ b/charts/service-base/values.schema.json
@@ -51,7 +51,7 @@
         "repository": {
           "type": "string",
           "minLength": 1,
-          "default": ""
+          "default": "ghcr.io/agynio/placeholder"
         },
         "tag": {
           "type": "string",
@@ -72,7 +72,7 @@
       },
       "default": {
         "registry": "",
-        "repository": "",
+        "repository": "ghcr.io/agynio/placeholder",
         "tag": "",
         "pullPolicy": "IfNotPresent",
         "pullSecrets": []

--- a/charts/service-base/values.yaml
+++ b/charts/service-base/values.yaml
@@ -9,7 +9,7 @@ global:
 
 image:
   registry: ""
-  repository: ""
+  repository: "ghcr.io/agynio/placeholder"
   tag: ""
   pullPolicy: IfNotPresent
   pullSecrets: []


### PR DESCRIPTION
## Summary
- set a non-empty placeholder image.repository default to satisfy schema
- document placeholder usage in README

## Testing
- helm lint charts/service-base
- helm template service-base-consumer /tmp/service-base-consumer --values /tmp/service-base-values.yaml

## Notes
- Closes #1
- Fixes lint failure in release workflow for v0.1.0.