### PR TITLE
chore: migrate helm registry

### DIFF
--- a/.github/workflows/release-chart.yaml
+++ b/.github/workflows/release-chart.yaml
@@ -43,4 +43,4 @@ jobs:
             -p "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Push chart
-        run: helm push "dist/service-base-$VERSION.tgz" oci://ghcr.io/agynio/helm
+        run: helm push "dist/service-base-$VERSION.tgz" oci://ghcr.io/agynio/charts

--- a/charts/service-base/README.md
+++ b/charts/service-base/README.md
@@ -13,7 +13,7 @@ Add the library chart as a dependency:
 dependencies:
   - name: service-base
     version: 0.1.0
-    repository: oci://ghcr.io/agynio/helm
+    repository: oci://ghcr.io/agynio/charts
 ```
 
 Then include the templates in your chart:


### PR DESCRIPTION
## Summary
- update release workflow to push charts to oci://ghcr.io/agynio/charts
- align README install instructions with the new registry path

## Testing
- helm lint charts/service-base
- helm template service-base-consumer /tmp/service-base-consumer --values /tmp/service-base-values.yaml

## Notes
- Closes #1